### PR TITLE
Fixed capitalization of the "Content-Type" header

### DIFF
--- a/dohq_teamcity/custom/client.py
+++ b/dohq_teamcity/custom/client.py
@@ -12,7 +12,7 @@ class TeamCity(ApiClient):
         if proxy is not None:
             configuration.proxy = proxy
         super(TeamCity, self).__init__(configuration=configuration)
-        self.default_headers.update({'Content-type': 'application/json',
+        self.default_headers.update({'Content-Type': 'application/json',
                                      'Accept': 'application/json',
                                      'Content-Encoding': 'utf-8'})
 


### PR DESCRIPTION
It seems like the Content-Type header is spelt the same all across the source code of this library, except in this one place: Here in line 15, it used to be "Content-type".
This could lead to issues in certain server setups: The "Content-Type" header is added if it is missing. Due to the two different spellings, it may not be identified as the same by parts of the code, and so one can potentially end up with a duplicate Content-Type header (see also https://github.com/devopshq/teamcity/blame/develop/dohq_teamcity/rest.py).

The resulting error message in such cases looks like this:
```
Reason:
HTTP response headers: HTTPHeaderDict({'Date': 'Thu, 14 Jan 2021 19:27:22 GMT', 'Server': 'Apache/2.4.41 (Win64) OpenSSL/1.1.1c', 'TeamCity-Node-Id': 'MAIN_SERVER', 'Cache-Control': 'no-store', 'Content-Type': 'text/html;charset=ISO-8859-1', 'Content-Language': 'en-NZ', 'Content-Length': '85', 'Set-Cookie': 'TCSESSIONID=xxxx; Path=/; HttpOnly, RememberMe=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly', 'Connection': 'close'})
HTTP response body:
400 Bad Content-Type header value: &#039;application/json, application/json&#039;
```

To avoid this situation, I suggest to set the spelling of "Content-Type" the same all across the source code.