### PR TITLE
Quick fix to allow API tokens to be used

### DIFF
--- a/dohq_teamcity/api_client.py
+++ b/dohq_teamcity/api_client.py
@@ -77,7 +77,6 @@ class ApiClient(object):
 
     def __del__(self):
         self.pool.close()
-        self.pool.join()
 
     @property
     def user_agent(self):

--- a/dohq_teamcity/configuration.py
+++ b/dohq_teamcity/configuration.py
@@ -61,6 +61,9 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
         # Password for HTTP basic authentication
         self.password = ""
 
+        # key in dict of api key to use
+        self.active_api_key = ""
+
         # Logging Settings
         self.logger = {}
         self.logger["package_logger"] = logging.getLogger("dohq_teamcity")
@@ -231,8 +234,14 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_basic_auth_token()
                 },
-
-        }
+            'Token':
+                {
+                    'type': 'token',
+                    'in': 'header',
+                    'key': 'Authorization',
+                    'value': self.get_api_key_with_prefix(self.active_api_key)
+                }
+            }
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/dohq_teamcity/custom/client.py
+++ b/dohq_teamcity/custom/client.py
@@ -4,11 +4,12 @@ from dohq_teamcity.custom.api import *
 
 
 class TeamCity(ApiClient):
-    def __init__(self, url, auth, proxy=None, configuration=None):
+    def __init__(self, url, auth=["Basic"], proxy=None, configuration=None):
         configuration = configuration or Configuration()
         configuration.host = url
         if isinstance(auth, tuple):
             configuration.username, configuration.password = auth
+        self.auth_settings = auth
         if proxy is not None:
             configuration.proxy = proxy
         super(TeamCity, self).__init__(configuration=configuration)
@@ -65,7 +66,7 @@ class TeamCity(ApiClient):
         """
         Quick hack for add Basic auth to swagger-codegen python
         """
-        kwargs['auth_settings'] = ['Basic']
+        kwargs['auth_settings'] = self.auth_settings
         return super(TeamCity, self).call_api(*args, **kwargs)
 
     def to_str(self):


### PR DESCRIPTION
I've modified this library with minimal changes to support being able to use a TeamCity access token. 

I'm not entirely sure why there was some functionality to enable this, but it was not fully implemented. 

Usage:
```
from dohq_teamcity import TeamCity
from dohq_teamcity.configuration import Configuration

config = Configuration()
config.api_key = {'mytoken': 'XXXXXXXXXXXXXXX'}
config.api_key_prefix = {'mytoken': 'Bearer'}
config.active_api_key = 'mytoken'

tc = TeamCity("https://teamcity.example.uk", auth=["Token"], configuration=config)
```