### PR TITLE
Bugfix: "... has no attribute 'swagger_types'"

### DIFF
--- a/docs-sphinx/swagger/api/BuildApi.rst
+++ b/docs-sphinx/swagger/api/BuildApi.rst
@@ -956,7 +956,7 @@ get_metadata
      - [optional] 
 
 Return type:
-    `file <../models/file.html>`_
+    `File <../models/File.html>`_
 
 `Back to top <#>`_
 

--- a/docs-sphinx/swagger/api/BuildTypeApi.rst
+++ b/docs-sphinx/swagger/api/BuildTypeApi.rst
@@ -2583,7 +2583,7 @@ get_metadata
      - [optional] 
 
 Return type:
-    `file <../models/file.html>`_
+    `File <../models/File.html>`_
 
 `Back to top <#>`_
 

--- a/docs-sphinx/swagger/api/ServerApi.rst
+++ b/docs-sphinx/swagger/api/ServerApi.rst
@@ -542,7 +542,7 @@ get_metadata
      - [optional] 
 
 Return type:
-    `file <../models/file.html>`_
+    `File <../models/File.html>`_
 
 `Back to top <#>`_
 

--- a/docs-sphinx/swagger/api/VcsRootInstanceApi.rst
+++ b/docs-sphinx/swagger/api/VcsRootInstanceApi.rst
@@ -381,7 +381,7 @@ get_metadata
      - [optional] 
 
 Return type:
-    `file <../models/file.html>`_
+    `File <../models/File.html>`_
 
 `Back to top <#>`_
 

--- a/docs-sphinx/swagger/models/File.rst
+++ b/docs-sphinx/swagger/models/File.rst
@@ -31,7 +31,7 @@ Properties
      - **str**
      - `optional` 
    * - **parent**
-     -  `file <./file.html>`_
+     -  `File <./File.html>`_
      - `optional` 
    * - **content**
      -  `Href <./Href.html>`_

--- a/docs-sphinx/swagger/models/Files.rst
+++ b/docs-sphinx/swagger/models/Files.rst
@@ -22,7 +22,7 @@ Properties
      - **str**
      - `optional` 
    * - **file**
-     -  `list[file] <./file.html>`_
+     -  `list[File] <./File.html>`_
      - `optional` 
 
 

--- a/dohq_teamcity/api/build_api.py
+++ b/dohq_teamcity/api/build_api.py
@@ -2233,8 +2233,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2427,8 +2427,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2518,8 +2518,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2608,8 +2608,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -3420,8 +3420,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/build_api.py
+++ b/dohq_teamcity/api/build_api.py
@@ -24,6 +24,7 @@ from dohq_teamcity.models.build_cancel_request import BuildCancelRequest  # noqa
 from dohq_teamcity.models.build_changes import BuildChanges  # noqa: F401,E501
 from dohq_teamcity.models.builds import Builds  # noqa: F401,E501
 from dohq_teamcity.models.comment import Comment  # noqa: F401,E501
+from dohq_teamcity.models.file import File  # noqa: F401,E501
 from dohq_teamcity.models.files import Files  # noqa: F401,E501
 from dohq_teamcity.models.issues_usages import IssuesUsages  # noqa: F401,E501
 from dohq_teamcity.models.model_property import ModelProperty  # noqa: F401,E501
@@ -31,7 +32,6 @@ from dohq_teamcity.models.problem_occurrences import ProblemOccurrences  # noqa:
 from dohq_teamcity.models.properties import Properties  # noqa: F401,E501
 from dohq_teamcity.models.tags import Tags  # noqa: F401,E501
 from dohq_teamcity.models.test_occurrences import TestOccurrences  # noqa: F401,E501
-from dohq_teamcity.models.file import file  # noqa: F401,E501
 
 
 class BuildApi(object):
@@ -444,7 +444,7 @@ class BuildApi(object):
         :param str fields:
         :param bool resolve_parameters:
         :param bool log_build_usage:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -2579,7 +2579,7 @@ class BuildApi(object):
         :param str fields:
         :param bool resolve_parameters:
         :param bool log_build_usage:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -2649,7 +2649,7 @@ class BuildApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='file',  # noqa: E501
+            response_type='File',  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/dohq_teamcity/api/build_type_api.py
+++ b/dohq_teamcity/api/build_type_api.py
@@ -5635,8 +5635,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -5823,8 +5823,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -5911,8 +5911,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -6786,8 +6786,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -9067,8 +9067,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/build_type_api.py
+++ b/dohq_teamcity/api/build_type_api.py
@@ -30,6 +30,7 @@ from dohq_teamcity.models.build_types import BuildTypes  # noqa: F401,E501
 from dohq_teamcity.models.builds import Builds  # noqa: F401,E501
 from dohq_teamcity.models.feature import Feature  # noqa: F401,E501
 from dohq_teamcity.models.features import Features  # noqa: F401,E501
+from dohq_teamcity.models.file import File  # noqa: F401,E501
 from dohq_teamcity.models.files import Files  # noqa: F401,E501
 from dohq_teamcity.models.investigations import Investigations  # noqa: F401,E501
 from dohq_teamcity.models.items import Items  # noqa: F401,E501
@@ -48,7 +49,6 @@ from dohq_teamcity.models.vcs_labeling import VcsLabeling  # noqa: F401,E501
 from dohq_teamcity.models.vcs_root_entries import VcsRootEntries  # noqa: F401,E501
 from dohq_teamcity.models.vcs_root_entry import VcsRootEntry  # noqa: F401,E501
 from dohq_teamcity.models.vcs_root_instances import VcsRootInstances  # noqa: F401,E501
-from dohq_teamcity.models.file import file  # noqa: F401,E501
 
 
 class BuildTypeApi(object):
@@ -1189,7 +1189,7 @@ class BuildTypeApi(object):
         :param str bt_locator: (required)
         :param str fields:
         :param bool resolve_parameters:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -6757,7 +6757,7 @@ class BuildTypeApi(object):
         :param str bt_locator: (required)
         :param str fields:
         :param bool resolve_parameters:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -6825,7 +6825,7 @@ class BuildTypeApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='file',  # noqa: E501
+            response_type='File',  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/dohq_teamcity/api/debug_api.py
+++ b/dohq_teamcity/api/debug_api.py
@@ -1836,8 +1836,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `get_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `extra` when calling `get_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `get_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2566,8 +2566,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `post_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `extra` when calling `post_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `post_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2639,8 +2639,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `put_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `extra` when calling `put_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `put_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/server_api.py
+++ b/dohq_teamcity/api/server_api.py
@@ -672,8 +672,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -854,8 +854,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -939,8 +939,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1225,8 +1225,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1393,8 +1393,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/server_api.py
+++ b/dohq_teamcity/api/server_api.py
@@ -20,13 +20,13 @@ import re  # noqa: F401
 import six
 
 from dohq_teamcity.models.backup_process_manager import BackupProcessManager  # noqa: F401,E501
+from dohq_teamcity.models.file import File  # noqa: F401,E501
 from dohq_teamcity.models.files import Files  # noqa: F401,E501
 from dohq_teamcity.models.license_key import LicenseKey  # noqa: F401,E501
 from dohq_teamcity.models.license_keys import LicenseKeys  # noqa: F401,E501
 from dohq_teamcity.models.licensing_data import LicensingData  # noqa: F401,E501
 from dohq_teamcity.models.plugins import Plugins  # noqa: F401,E501
 from dohq_teamcity.models.server import Server  # noqa: F401,E501
-from dohq_teamcity.models.file import file  # noqa: F401,E501
 
 
 class ServerApi(object):
@@ -275,7 +275,7 @@ class ServerApi(object):
         :param str path: (required)
         :param str area_id: (required)
         :param str fields:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -1196,7 +1196,7 @@ class ServerApi(object):
         :param str path: (required)
         :param str area_id: (required)
         :param str fields:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -1262,7 +1262,7 @@ class ServerApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='file',  # noqa: E501
+            response_type='File',  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/dohq_teamcity/api/vcs_root_instance_api.py
+++ b/dohq_teamcity/api/vcs_root_instance_api.py
@@ -665,8 +665,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -847,8 +847,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -932,8 +932,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1016,8 +1016,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1329,8 +1329,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError(r"Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/vcs_root_instance_api.py
+++ b/dohq_teamcity/api/vcs_root_instance_api.py
@@ -20,11 +20,11 @@ import re  # noqa: F401
 import six
 
 from dohq_teamcity.models.entries import Entries  # noqa: F401,E501
+from dohq_teamcity.models.file import File  # noqa: F401,E501
 from dohq_teamcity.models.files import Files  # noqa: F401,E501
 from dohq_teamcity.models.properties import Properties  # noqa: F401,E501
 from dohq_teamcity.models.vcs_root_instance import VcsRootInstance  # noqa: F401,E501
 from dohq_teamcity.models.vcs_root_instances import VcsRootInstances  # noqa: F401,E501
-from dohq_teamcity.models.file import file  # noqa: F401,E501
 
 
 class VcsRootInstanceApi(object):
@@ -188,7 +188,7 @@ class VcsRootInstanceApi(object):
         :param str path: (required)
         :param str vcs_root_instance_locator: (required)
         :param str fields:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -987,7 +987,7 @@ class VcsRootInstanceApi(object):
         :param str path: (required)
         :param str vcs_root_instance_locator: (required)
         :param str fields:
-        :return: file
+        :return: File
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -1053,7 +1053,7 @@ class VcsRootInstanceApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='file',  # noqa: E501
+            response_type='File',  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/dohq_teamcity/configuration.py
+++ b/dohq_teamcity/configuration.py
@@ -241,7 +241,7 @@ class Configuration(six.with_metaclass(TypeWithDefault, object)):
                     'key': 'Authorization',
                     'value': self.get_api_key_with_prefix(self.active_api_key)
                 }
-            }
+        }
 
     def to_debug_report(self):
         """Gets the essential information for debugging.

--- a/dohq_teamcity/custom/models.py
+++ b/dohq_teamcity/custom/models.py
@@ -3515,8 +3515,6 @@ class Properties(Properties, ContainerMixin):
         return next((x for x in self.data if x.name == name), None)
 
 
-
-
 class VcsRootEntries(VcsRootEntries, ContainerMixin):
     @property
     def _container_mixin_data(self):

--- a/dohq_teamcity/models/file.py
+++ b/dohq_teamcity/models/file.py
@@ -3,7 +3,7 @@
 from dohq_teamcity.custom.base_model import TeamCityObject
 
 
-# from dohq_teamcity.models.file import file  # noqa: F401,E501
+# from dohq_teamcity.models.file import File  # noqa: F401,E501
 # from dohq_teamcity.models.files import Files  # noqa: F401,E501
 # from dohq_teamcity.models.href import Href  # noqa: F401,E501
 
@@ -27,7 +27,7 @@ class File(TeamCityObject):
         'size': 'int',
         'modification_time': 'str',
         'href': 'str',
-        'parent': 'file',
+        'parent': 'File',
         'content': 'Href',
         'children': 'Files'
     }
@@ -185,7 +185,7 @@ class File(TeamCityObject):
 
 
         :return: The parent of this File.  # noqa: E501
-        :rtype: file
+        :rtype: File
         """
         return self._parent
 
@@ -195,7 +195,7 @@ class File(TeamCityObject):
 
 
         :param parent: The parent of this File.  # noqa: E501
-        :type: file
+        :type: File
         """
 
         self._parent = parent

--- a/dohq_teamcity/models/files.py
+++ b/dohq_teamcity/models/files.py
@@ -3,7 +3,7 @@
 from dohq_teamcity.custom.base_model import TeamCityObject
 
 
-# from dohq_teamcity.models.file import file  # noqa: F401,E501
+# from dohq_teamcity.models.file import File  # noqa: F401,E501
 
 
 class Files(TeamCityObject):
@@ -22,7 +22,7 @@ class Files(TeamCityObject):
     swagger_types = {
         'count': 'int',
         'href': 'str',
-        'file': 'list[file]'
+        'file': 'list[File]'
     }
 
     attribute_map = {
@@ -95,7 +95,7 @@ class Files(TeamCityObject):
 
 
         :return: The file of this Files.  # noqa: E501
-        :rtype: list[file]
+        :rtype: list[File]
         """
         return self._file
 
@@ -105,7 +105,7 @@ class Files(TeamCityObject):
 
 
         :param file: The file of this Files.  # noqa: E501
-        :type: list[file]
+        :type: list[File]
         """
 
         self._file = file

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5236,7 +5236,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -5344,7 +5344,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -5462,7 +5462,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/file"
+              "$ref": "#/definitions/File"
             },
             "headers": {}
           }
@@ -5518,7 +5518,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -6027,7 +6027,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -6147,7 +6147,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -6283,7 +6283,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/file"
+              "$ref": "#/definitions/File"
             },
             "headers": {}
           }
@@ -6345,7 +6345,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -11813,7 +11813,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -11909,7 +11909,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -12009,7 +12009,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/file"
+              "$ref": "#/definitions/File"
             },
             "headers": {}
           }
@@ -12059,7 +12059,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -13890,7 +13890,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -13986,7 +13986,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -14086,7 +14086,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/file"
+              "$ref": "#/definitions/File"
             },
             "headers": {}
           }
@@ -14136,7 +14136,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/files"
+              "$ref": "#/definitions/Files"
             },
             "headers": {}
           }
@@ -16261,7 +16261,7 @@
           "$ref": "#/definitions/problemOccurrences"
         },
         "artifacts": {
-          "$ref": "#/definitions/files"
+          "$ref": "#/definitions/Files"
         },
         "relatedIssues": {
           "$ref": "#/definitions/issuesUsages"
@@ -17053,7 +17053,7 @@
         "name": "federationServer"
       }
     },
-    "file": {
+    "File": {
       "type": "object",
       "properties": {
         "name": {
@@ -17088,20 +17088,20 @@
           }
         },
         "parent": {
-          "$ref": "#/definitions/file"
+          "$ref": "#/definitions/File"
         },
         "content": {
           "$ref": "#/definitions/href"
         },
         "children": {
-          "$ref": "#/definitions/files"
+          "$ref": "#/definitions/Files"
         }
       },
       "xml": {
         "name": "file"
       }
     },
-    "files": {
+    "Files": {
       "type": "object",
       "properties": {
         "count": {
@@ -17120,7 +17120,7 @@
         "file": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/file"
+            "$ref": "#/definitions/File"
           }
         }
       },


### PR DESCRIPTION
Rename 'file' and 'files' definitions to 'File' and 'Files'.
The lowercase name caused python to mix model declaration and python
module name. As a result, deserializer got 'file' module as 'klass'
argument instead of File model definition.

This caused attribute error exception in deserializer.

fixes #25

The only real change here is `swagger/swagger.json` file. 
All the rest are code regen results.