### PR TITLE
Add host attribute to the Agent object

### DIFF
--- a/docs-sphinx/swagger/api/BuildApi.rst
+++ b/docs-sphinx/swagger/api/BuildApi.rst
@@ -819,7 +819,7 @@ get_content
 
     try:
         api_response = tc.build_api.get_content(path, build_locator, response_builder=response_builder, resolve_parameters=resolve_parameters, log_build_usage=log_build_usage)
-        pprint(api_response)
+       pprint(api_response)
     except ApiException as e:
         print("Exception when calling BuildApi->get_content: %s\n" % e)
 

--- a/docs-sphinx/swagger/models/Agent.rst
+++ b/docs-sphinx/swagger/models/Agent.rst
@@ -51,6 +51,9 @@ Properties
    * - **disconnection_comment**
      - **str**
      - `optional` 
+   * - **host**
+     - **str**
+     - `optional` 
    * - **href**
      - **str**
      - `optional` 

--- a/dohq_teamcity/models/agent.py
+++ b/dohq_teamcity/models/agent.py
@@ -40,6 +40,7 @@ class Agent(TeamCityObject):
         'version': 'str',
         'last_activity_time': 'str',
         'disconnection_comment': 'str',
+        'host': 'str',
         'href': 'str',
         'web_url': 'str',
         'build': 'Build',
@@ -67,6 +68,7 @@ class Agent(TeamCityObject):
         'version': 'version',
         'last_activity_time': 'lastActivityTime',
         'disconnection_comment': 'disconnectionComment',
+        'host': 'host',
         'href': 'href',
         'web_url': 'webUrl',
         'build': 'build',
@@ -81,7 +83,7 @@ class Agent(TeamCityObject):
         'locator': 'locator'
     }
 
-    def __init__(self, id=None, name=None, type_id=None, connected=False, enabled=False, authorized=False, uptodate=False, ip=None, protocol=None, version=None, last_activity_time=None, disconnection_comment=None, href=None, web_url=None, build=None, links=None, enabled_info=None, authorized_info=None, properties=None, environment=None, pool=None, compatible_build_types=None, incompatible_build_types=None, locator=None, teamcity=None):  # noqa: E501
+    def __init__(self, id=None, name=None, type_id=None, connected=False, enabled=False, authorized=False, uptodate=False, ip=None, protocol=None, version=None, last_activity_time=None, disconnection_comment=None, host=None, href=None, web_url=None, build=None, links=None, enabled_info=None, authorized_info=None, properties=None, environment=None, pool=None, compatible_build_types=None, incompatible_build_types=None, locator=None, teamcity=None):  # noqa: E501
         """Agent - a model defined in Swagger"""  # noqa: E501
 
         self._id = None
@@ -96,6 +98,7 @@ class Agent(TeamCityObject):
         self._version = None
         self._last_activity_time = None
         self._disconnection_comment = None
+        self._host = None
         self._href = None
         self._web_url = None
         self._build = None
@@ -134,6 +137,8 @@ class Agent(TeamCityObject):
             self.last_activity_time = last_activity_time
         if disconnection_comment is not None:
             self.disconnection_comment = disconnection_comment
+        if host is not None:
+            self.host = host
         if href is not None:
             self.href = href
         if web_url is not None:
@@ -411,6 +416,27 @@ class Agent(TeamCityObject):
         """
 
         self._disconnection_comment = disconnection_comment
+
+    @property
+    def host(self):
+        """Gets the host of this Agent.  # noqa: E501
+
+
+        :return: The host of this Agent.  # noqa: E501
+        :rtype: str
+        """
+        return self._host
+
+    @host.setter
+    def host(self, host):
+        """Sets the host of this Agent.
+
+
+        :param host: The host of this Agent.  # noqa: E501
+        :type: str
+        """
+
+        self._host = host
 
     @property
     def href(self):

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -15569,6 +15569,12 @@
             "attribute": true
           }
         },
+        "host": {
+          "type": "string",
+          "xml": {
+            "attribute": true
+          }
+        },
         "href": {
           "type": "string",
           "xml": {


### PR DESCRIPTION
For a local project, we found that the host attribute is being returned from the TeamCity server, but we are unable to access it in the Agent object.  According to the online docs, this is an official attribute so likely it was added since the last time the swagger.json was pulled.

Ideally we would pull the new swagger.json and re-generate everything based on the new swagger.json, but I found an enormous number of differences, including breaking changes if we do that.  For now, just adding this attribute is sufficient to make forward progress