### PR TITLE
 Fix invalid escape sequences for Python 3.12 compatibility (closes #55)

### DIFF
--- a/dohq_teamcity/api/build_api.py
+++ b/dohq_teamcity/api/build_api.py
@@ -2234,8 +2234,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2428,8 +2428,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2519,8 +2519,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2609,8 +2609,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -3421,8 +3421,8 @@ class BuildApi(object):
                 params['build_locator'] is None):
             raise ValueError("Missing the required parameter `build_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/build_type_api.py
+++ b/dohq_teamcity/api/build_type_api.py
@@ -5635,8 +5635,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -5823,8 +5823,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -5911,8 +5911,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -6786,8 +6786,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -9067,8 +9067,8 @@ class BuildTypeApi(object):
                 params['bt_locator'] is None):
             raise ValueError("Missing the required parameter `bt_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/debug_api.py
+++ b/dohq_teamcity/api/debug_api.py
@@ -1836,8 +1836,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `get_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `extra` when calling `get_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `get_request_details`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2566,8 +2566,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `post_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `extra` when calling `post_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `post_request_details`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -2639,8 +2639,8 @@ class DebugApi(object):
                 params['extra'] is None):
             raise ValueError("Missing the required parameter `extra` when calling `put_request_details`")  # noqa: E501
 
-        if 'extra' in params and not re.search('(\/.*)?', params['extra']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `extra` when calling `put_request_details`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'extra' in params and not re.search(r'(\/.*)?', params['extra']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `extra` when calling `put_request_details`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/server_api.py
+++ b/dohq_teamcity/api/server_api.py
@@ -672,8 +672,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -854,8 +854,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -939,8 +939,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1225,8 +1225,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1393,8 +1393,8 @@ class ServerApi(object):
                 params['area_id'] is None):
             raise ValueError("Missing the required parameter `area_id` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}

--- a/dohq_teamcity/api/vcs_root_instance_api.py
+++ b/dohq_teamcity/api/vcs_root_instance_api.py
@@ -665,8 +665,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_children`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_children`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -847,8 +847,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_content`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -932,8 +932,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_content_alias`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_content_alias`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1016,8 +1016,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_metadata`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_metadata`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}
@@ -1329,8 +1329,8 @@ class VcsRootInstanceApi(object):
                 params['vcs_root_instance_locator'] is None):
             raise ValueError("Missing the required parameter `vcs_root_instance_locator` when calling `get_zipped`")  # noqa: E501
 
-        if 'path' in params and not re.search('(\/.*)?', params['path']):  # noqa: E501
-            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern `/(\/.*)?/`")  # noqa: E501
+        if 'path' in params and not re.search(r'(\/.*)?', params['path']):  # noqa: E501
+            raise ValueError("Invalid value for parameter `path` when calling `get_zipped`, must conform to the pattern "+r"`/(\/.*)?/`")  # noqa: E501
         collection_formats = {}
 
         path_params = {}


### PR DESCRIPTION
This PR fixes `SyntaxWarning` issues in Python 3.12 caused by invalid escape sequences (`\/`).

✔️ Converted affected regex and string literals to use raw strings: `r"..."`  
✔️ Verified clean install with `setup.py install` on Python 3.12  
🔗 Closes #55
