### PR TITLE
Fix Python 3.13 destructor error

### DIFF
--- a/dohq_teamcity/api_client.py
+++ b/dohq_teamcity/api_client.py
@@ -76,7 +76,13 @@ class ApiClient(object):
         self.user_agent = 'Swagger-Codegen/1.0.0/python'
 
     def __del__(self):
-        self.pool.close()
+        """Cleanup thread pool when the client object is garbage collected."""
+        try:
+            self.pool.close()
+        except OSError:
+            # Python 3.13 can raise OSError("Bad file descriptor") when
+            # closing a pool during interpreter shutdown. Ignore it.
+            pass
 
     @property
     def user_agent(self):


### PR DESCRIPTION
## Summary
- avoid `OSError: Bad file descriptor` when ApiClient is garbage collected
- revert to simple try/except for closing the pool
- remove extra cleanup tests

## Testing
```bash
git clone https://github.com/devopshq/teamcity.git
cd teamcity
git checkout codex/fix-oserror-when-exiting-script-after-python-3.13-upgrade
pip install .
```

fix #59 

------
https://chatgpt.com/codex/tasks/task_e_68464a7f84948330b7b1379e8cfb85b5